### PR TITLE
fix: テキストツールのカーソルが十字になるバグを修正

### DIFF
--- a/packages/app/src/renderer/components/canvas/TransformHandles.tsx
+++ b/packages/app/src/renderer/components/canvas/TransformHandles.tsx
@@ -96,6 +96,7 @@ function getInlineEditorBoundsFromDom(): Bounds | null {
 export function TransformHandles(): React.JSX.Element | null {
   const document = useAppStore((s) => s.document);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
+  const activeTool = useAppStore((s) => s.activeTool);
   const zoom = useAppStore((s) => s.zoom);
   const revision = useAppStore((s) => s.revision);
   const resizeLayer = useAppStore((s) => s.resizeLayer);
@@ -151,6 +152,9 @@ export function TransformHandles(): React.JSX.Element | null {
   const layer = findLayerById(document.rootGroup, selectedLayerId);
   if (!layer || (layer.type !== 'raster' && layer.type !== 'text')) return null;
   const isEditingSelectedTextLayer = layer.type === 'text' && editingTextLayerId === layer.id;
+  // When the text tool is active, disable handle interaction so clicks pass
+  // through to the canvas for text creation/editing (Issue #5).
+  const handlesInteractive = activeTool !== 'text';
 
   // Get layer bounds in document coordinates.
   let layerBounds: Bounds;
@@ -364,8 +368,9 @@ export function TransformHandles(): React.JSX.Element | null {
           top: `${sy - MOVE_HIT_SIZE / 2}px`,
           width: `${Math.max(1, sw - HANDLE_SIZE)}px`,
           height: `${MOVE_HIT_SIZE}px`,
+          pointerEvents: handlesInteractive ? 'all' : 'none',
         }}
-        onMouseDown={(e): void => startDrag(e, 'move')}
+        onMouseDown={handlesInteractive ? (e): void => startDrag(e, 'move') : undefined}
       />
       <div
         className="transform-move-hit"
@@ -375,8 +380,9 @@ export function TransformHandles(): React.JSX.Element | null {
           top: `${sy + half}px`,
           width: `${MOVE_HIT_SIZE}px`,
           height: `${Math.max(1, sh - HANDLE_SIZE)}px`,
+          pointerEvents: handlesInteractive ? 'all' : 'none',
         }}
-        onMouseDown={(e): void => startDrag(e, 'move')}
+        onMouseDown={handlesInteractive ? (e): void => startDrag(e, 'move') : undefined}
       />
       <div
         className="transform-move-hit"
@@ -386,8 +392,9 @@ export function TransformHandles(): React.JSX.Element | null {
           top: `${sy + sh - MOVE_HIT_SIZE / 2}px`,
           width: `${Math.max(1, sw - HANDLE_SIZE)}px`,
           height: `${MOVE_HIT_SIZE}px`,
+          pointerEvents: handlesInteractive ? 'all' : 'none',
         }}
-        onMouseDown={(e): void => startDrag(e, 'move')}
+        onMouseDown={handlesInteractive ? (e): void => startDrag(e, 'move') : undefined}
       />
       <div
         className="transform-move-hit"
@@ -397,23 +404,25 @@ export function TransformHandles(): React.JSX.Element | null {
           top: `${sy + half}px`,
           width: `${MOVE_HIT_SIZE}px`,
           height: `${Math.max(1, sh - HANDLE_SIZE)}px`,
+          pointerEvents: handlesInteractive ? 'all' : 'none',
         }}
-        onMouseDown={(e): void => startDrag(e, 'move')}
+        onMouseDown={handlesInteractive ? (e): void => startDrag(e, 'move') : undefined}
       />
       {/* 8 resize handles */}
       {handles.map((h) => (
         <div
           key={h.position}
-          className="transform-handle"
+          className={`transform-handle${handlesInteractive ? '' : ' transform-handle--inactive'}`}
           data-testid={`handle-${h.position}`}
           style={{
             left: `${h.x}px`,
             top: `${h.y}px`,
             width: `${HANDLE_SIZE}px`,
             height: `${HANDLE_SIZE}px`,
-            cursor: HANDLE_CURSORS[h.position],
+            cursor: handlesInteractive ? HANDLE_CURSORS[h.position] : 'inherit',
+            pointerEvents: handlesInteractive ? 'all' : 'none',
           }}
-          onMouseDown={(e): void => startDrag(e, 'resize', h.position)}
+          onMouseDown={handlesInteractive ? (e): void => startDrag(e, 'resize', h.position) : undefined}
         />
       ))}
     </div>

--- a/packages/app/src/renderer/components/canvas/TransformHandles.tsx
+++ b/packages/app/src/renderer/components/canvas/TransformHandles.tsx
@@ -152,10 +152,12 @@ export function TransformHandles(): React.JSX.Element | null {
   const layer = findLayerById(document.rootGroup, selectedLayerId);
   if (!layer || (layer.type !== 'raster' && layer.type !== 'text')) return null;
   const isEditingSelectedTextLayer = layer.type === 'text' && editingTextLayerId === layer.id;
-  // When the text tool is active but NOT editing, disable handle interaction
-  // so clicks pass through to the canvas for text creation/editing (Issue #5).
-  // When actively editing a text layer, keep handles interactive for resizing.
-  const handlesInteractive = activeTool !== 'text' || isEditingSelectedTextLayer;
+  // When the text tool is active, disable move-hit areas so the canvas cursor
+  // stays as I-beam and clicks pass through for text creation/editing (Issue #5).
+  // Resize handles remain interactive during text editing for box resizing.
+  const isTextToolActive = activeTool === 'text';
+  const moveHitsInteractive = !isTextToolActive;
+  const resizeHandlesInteractive = !isTextToolActive || isEditingSelectedTextLayer;
 
   // Get layer bounds in document coordinates.
   let layerBounds: Bounds;
@@ -369,9 +371,9 @@ export function TransformHandles(): React.JSX.Element | null {
           top: `${sy - MOVE_HIT_SIZE / 2}px`,
           width: `${Math.max(1, sw - HANDLE_SIZE)}px`,
           height: `${MOVE_HIT_SIZE}px`,
-          pointerEvents: handlesInteractive ? 'all' : 'none',
+          pointerEvents: moveHitsInteractive ? 'all' : 'none',
         }}
-        onMouseDown={handlesInteractive ? (e): void => startDrag(e, 'move') : undefined}
+        onMouseDown={moveHitsInteractive ? (e): void => startDrag(e, 'move') : undefined}
       />
       <div
         className="transform-move-hit"
@@ -381,9 +383,9 @@ export function TransformHandles(): React.JSX.Element | null {
           top: `${sy + half}px`,
           width: `${MOVE_HIT_SIZE}px`,
           height: `${Math.max(1, sh - HANDLE_SIZE)}px`,
-          pointerEvents: handlesInteractive ? 'all' : 'none',
+          pointerEvents: moveHitsInteractive ? 'all' : 'none',
         }}
-        onMouseDown={handlesInteractive ? (e): void => startDrag(e, 'move') : undefined}
+        onMouseDown={moveHitsInteractive ? (e): void => startDrag(e, 'move') : undefined}
       />
       <div
         className="transform-move-hit"
@@ -393,9 +395,9 @@ export function TransformHandles(): React.JSX.Element | null {
           top: `${sy + sh - MOVE_HIT_SIZE / 2}px`,
           width: `${Math.max(1, sw - HANDLE_SIZE)}px`,
           height: `${MOVE_HIT_SIZE}px`,
-          pointerEvents: handlesInteractive ? 'all' : 'none',
+          pointerEvents: moveHitsInteractive ? 'all' : 'none',
         }}
-        onMouseDown={handlesInteractive ? (e): void => startDrag(e, 'move') : undefined}
+        onMouseDown={moveHitsInteractive ? (e): void => startDrag(e, 'move') : undefined}
       />
       <div
         className="transform-move-hit"
@@ -405,25 +407,25 @@ export function TransformHandles(): React.JSX.Element | null {
           top: `${sy + half}px`,
           width: `${MOVE_HIT_SIZE}px`,
           height: `${Math.max(1, sh - HANDLE_SIZE)}px`,
-          pointerEvents: handlesInteractive ? 'all' : 'none',
+          pointerEvents: moveHitsInteractive ? 'all' : 'none',
         }}
-        onMouseDown={handlesInteractive ? (e): void => startDrag(e, 'move') : undefined}
+        onMouseDown={moveHitsInteractive ? (e): void => startDrag(e, 'move') : undefined}
       />
       {/* 8 resize handles */}
       {handles.map((h) => (
         <div
           key={h.position}
-          className={`transform-handle${handlesInteractive ? '' : ' transform-handle--inactive'}`}
+          className={`transform-handle${resizeHandlesInteractive ? '' : ' transform-handle--inactive'}`}
           data-testid={`handle-${h.position}`}
           style={{
             left: `${h.x}px`,
             top: `${h.y}px`,
             width: `${HANDLE_SIZE}px`,
             height: `${HANDLE_SIZE}px`,
-            cursor: handlesInteractive ? HANDLE_CURSORS[h.position] : 'inherit',
-            pointerEvents: handlesInteractive ? 'all' : 'none',
+            cursor: resizeHandlesInteractive ? HANDLE_CURSORS[h.position] : 'inherit',
+            pointerEvents: resizeHandlesInteractive ? 'all' : 'none',
           }}
-          onMouseDown={handlesInteractive ? (e): void => startDrag(e, 'resize', h.position) : undefined}
+          onMouseDown={resizeHandlesInteractive ? (e): void => startDrag(e, 'resize', h.position) : undefined}
         />
       ))}
     </div>

--- a/packages/app/src/renderer/components/canvas/TransformHandles.tsx
+++ b/packages/app/src/renderer/components/canvas/TransformHandles.tsx
@@ -152,9 +152,10 @@ export function TransformHandles(): React.JSX.Element | null {
   const layer = findLayerById(document.rootGroup, selectedLayerId);
   if (!layer || (layer.type !== 'raster' && layer.type !== 'text')) return null;
   const isEditingSelectedTextLayer = layer.type === 'text' && editingTextLayerId === layer.id;
-  // When the text tool is active, disable handle interaction so clicks pass
-  // through to the canvas for text creation/editing (Issue #5).
-  const handlesInteractive = activeTool !== 'text';
+  // When the text tool is active but NOT editing, disable handle interaction
+  // so clicks pass through to the canvas for text creation/editing (Issue #5).
+  // When actively editing a text layer, keep handles interactive for resizing.
+  const handlesInteractive = activeTool !== 'text' || isEditingSelectedTextLayer;
 
   // Get layer bounds in document coordinates.
   let layerBounds: Bounds;


### PR DESCRIPTION
## Summary
- テキストツール選択時に `TransformHandles` の move-hit エリア（`pointer-events: all` + `cursor: move`）がキャンバス上に重なり、Iビームカーソルが表示されずクリックも横取りされていた問題を修正
- `activeTool === 'text'` の時、ハンドルとmove-hitエリアを `pointer-events: none` にしてバウンディングボックスの表示のみ残す

## Test plan
- [ ] テキストツールを選択し、キャンバス上でIビーム（テキスト入力）カーソルが表示されることを確認
- [ ] テキストツールでキャンバスをクリックし、新規テキストレイヤーが作成されることを確認
- [ ] 既存テキストレイヤー上でクリックし、編集モードに入れることを確認
- [ ] select/move ツールに切り替えた時、TransformHandlesが従来通りドラッグ移動・リサイズできることを確認

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)