### PR TITLE
fix: テキストカーソル位置ズレを解消 #8

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -58,7 +58,7 @@ import { HistoryPanel } from './components/panels/HistoryPanel';
 import { AdjustmentsDialog } from './components/dialogs/AdjustmentsDialog';
 import { ImageSizeDialog } from './components/dialogs/ImageSizeDialog';
 import { CanvasSizeDialog } from './components/dialogs/CanvasSizeDialog';
-import { TextPropertiesPanel, InlineTextEditor } from './components/text-editor';
+import { TextPropertiesPanel } from './components/text-editor';
 import { TemplateDialog } from './components/dialogs/TemplateDialog';
 import { BackgroundDialog } from './components/dialogs/BackgroundDialog';
 import { PatternDialog } from './components/dialogs/PatternDialog';
@@ -281,7 +281,6 @@ export function App(): React.JSX.Element {
   const hideContextMenu = useAppStore((s) => s.hideContextMenu);
   const showAbout = useAppStore((s) => s.showAbout);
   const toggleAbout = useAppStore((s) => s.toggleAbout);
-  const editingTextLayerId = useAppStore((s) => s.editingTextLayerId);
   const layerStyleDialog = useAppStore((s) => s.layerStyleDialog);
   const stopEditingText = useAppStore((s) => s.stopEditingText);
   const dragOverActive = useAppStore((s) => s.dragOverActive);
@@ -757,7 +756,6 @@ export function App(): React.JSX.Element {
       <PatternDialog />
       <BorderDialog />
       <GradientMaskDialog />
-      {editingTextLayerId && <InlineTextEditor />}
       {layerStyleDialog && <LayerStyleDialog />}
       {dragOverActive && (
         <div className="drag-overlay">

--- a/packages/app/src/renderer/components/canvas/CanvasView.tsx
+++ b/packages/app/src/renderer/components/canvas/CanvasView.tsx
@@ -35,6 +35,7 @@ import { t } from '../../i18n';
 import { TransformHandles } from './TransformHandles';
 import { SelectionOverlay } from './SelectionOverlay';
 import { CutoutTool } from '../tools/CutoutTool';
+import { InlineTextEditor } from '../text-editor';
 import { spacePanState } from './spacePanState';
 import { getTextLayerHitBounds, isPointInBounds } from './text-hit-test';
 
@@ -766,6 +767,7 @@ export function CanvasView(): React.JSX.Element {
             className="editor-canvas"
           />
           <TransformHandles />
+          {editingTextLayerId && <InlineTextEditor />}
           <SelectionOverlay />
           <CutoutTool />
           {isBrushTool && (

--- a/packages/app/src/renderer/components/text-editor/InlineTextEditor.tsx
+++ b/packages/app/src/renderer/components/text-editor/InlineTextEditor.tsx
@@ -281,12 +281,10 @@ export function InlineTextEditor(): React.JSX.Element | null {
     y: activePreview?.y ?? textLayer.position.y,
   });
 
-  // Account for the canvas-area element offset
-  const canvasArea = globalThis.document.querySelector('.canvas-area');
-  const canvasRect = canvasArea?.getBoundingClientRect() ?? { left: 0, top: 0 };
-
-  const left = canvasRect.left + screenPos.x;
-  const top = canvasRect.top + screenPos.y;
+  // The editor is rendered inside .canvas-area (position: relative),
+  // so screen coordinates from documentToScreen are used directly.
+  const left = screenPos.x;
+  const top = screenPos.y;
   const fontSize = textLayer.fontSize * zoom;
 
   // If textBounds exists, set initial size in screen coordinates

--- a/packages/app/src/renderer/store.test.ts
+++ b/packages/app/src/renderer/store.test.ts
@@ -32,26 +32,6 @@ function createTestDocument(): void {
 /** Helper: number of children including the default background layer. */
 const BG = 1;
 
-function resetStore(): void {
-  useAppStore.setState({
-    document: null,
-    activeTool: 'select',
-    zoom: 1,
-    panOffset: { x: 0, y: 0 },
-    statusMessage: 'Ready',
-    showAbout: false,
-    selectedLayerId: null,
-    canUndo: false,
-    canRedo: false,
-    revision: 0,
-    contextMenu: null,
-  });
-}
-
-function createTestDocument(): void {
-  useAppStore.getState().newDocument('Test', 800, 600);
-}
-
 describe('useAppStore', () => {
   beforeEach(() => {
     resetStore();

--- a/packages/app/src/renderer/styles.css
+++ b/packages/app/src/renderer/styles.css
@@ -788,9 +788,9 @@ html, body, #root {
 
 /* Inline Text Editor — PS-TEXT-005 (custom overlay, no OS-native textarea) */
 .inline-text-editor {
-  position: fixed;
+  position: absolute;
   z-index: 100;
-  padding: 2px 4px;
+  padding: 0;
   border: none;
   border-radius: 0;
   background: transparent;
@@ -798,7 +798,7 @@ html, body, #root {
   outline: none;
   overflow: visible;
   min-width: 1px;
-  min-height: 1.5em;
+  min-height: 1em;
   white-space: pre-wrap;
   word-break: break-word;
   -webkit-user-select: text;


### PR DESCRIPTION
## Summary
- InlineTextEditorをApp.tsx（canvas-area外, position:fixed）からCanvasView.tsx（canvas-area内, position:absolute）に移動
- TransformHandlesと同じ座標基準になりカーソル位置のズレを解消
- 不要なcanvasRect.getBoundingClientRect()オフセット計算、padding、余分なmin-heightを削除
- store.test.tsの重複関数宣言バグも併せて修正

## Test plan
- [x] `pnpm lint` — PASS
- [x] `pnpm test` — 989 tests PASS
- [x] `pnpm build` — PASS
- [ ] テキストツールでキャンバスクリック → カーソルがバウンディングボックス内に表示されることを確認
- [ ] 既存テキストレイヤーをダブルクリック → 編集カーソルが正しい位置に表示されることを確認
- [ ] ズーム・パン操作後もカーソル位置がズレないことを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)